### PR TITLE
Fix “Github” → “GitHub” typo

### DIFF
--- a/src/components/panels/index.tsx
+++ b/src/components/panels/index.tsx
@@ -49,25 +49,25 @@ export const Panels: React.SFC = () => (
       <Title>shepherd</Title>
       <Subheading>client-side JSON-RPC node²-balancing</Subheading>
       <FlexSpacer />
-      <Link href="https://github.com/MyCryptoHQ/shepherd">Github</Link>
+      <Link href="https://github.com/MyCryptoHQ/shepherd">GitHub</Link>
     </Card>
     <Card>
       <Title>typ3</Title>
       <Subheading>typesafe smart contract interaction</Subheading>
       <FlexSpacer />
-      <Link href="https://github.com/MyCryptoHQ/typ3">Github</Link>
+      <Link href="https://github.com/MyCryptoHQ/typ3">GitHub</Link>
     </Card>
     <Card>
       <Title>typ3-cli</Title>
       <Subheading>auto-generate typescript declaration files</Subheading>
       <FlexSpacer />
-      <Link href="https://github.com/MyCryptoHQ/typ3-cli">Github</Link>
+      <Link href="https://github.com/MyCryptoHQ/typ3-cli">GitHub</Link>
     </Card>
     <Card>
       <Title>drawbridge</Title>
       <Subheading>SPA release management and verification</Subheading>
       <FlexSpacer />
-      <Link href="https://github.com/MyCryptoHQ/drawbridge">Github</Link>
+      <Link href="https://github.com/MyCryptoHQ/drawbridge">GitHub</Link>
     </Card>
   </StyledWrapper>
 );


### PR DESCRIPTION
Just a small detail 😊 